### PR TITLE
Add Lenient Parsing

### DIFF
--- a/src/config/checkstyle.xml
+++ b/src/config/checkstyle.xml
@@ -63,7 +63,6 @@
         <module name="LeftCurly"/>
         <module name="NeedBraces"/>
         <module name="RightCurly"/>
-        <module name="AvoidInlineConditionals"/>
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>

--- a/src/main/java/us/springett/parsers/cpe/Cpe.java
+++ b/src/main/java/us/springett/parsers/cpe/Cpe.java
@@ -717,76 +717,76 @@ public class Cpe implements ICpe, Serializable {
     @Override
     public int compareTo(Object o) {
         if (o instanceof ICpe) {
-            ICpe other = (ICpe) o;
+            ICpe otherObject = (ICpe) o;
 
             final int before = -1;
             final int equal = 0;
             final int after = 1;
 
-            if (this == other) {
+            if (this == otherObject) {
                 return equal;
             }
-            int r = getPart().getAbbreviation().compareTo(other.getPart().getAbbreviation());
+            int r = getPart().getAbbreviation().compareTo(otherObject.getPart().getAbbreviation());
             if (r < 0) {
                 return before;
             } else if (r > 0) {
                 return after;
             }
-            r = getVendor().compareTo(other.getVendor());
+            r = getVendor().compareTo(otherObject.getVendor());
             if (r < 0) {
                 return before;
             } else if (r > 0) {
                 return after;
             }
-            r = getProduct().compareTo(other.getProduct());
+            r = getProduct().compareTo(otherObject.getProduct());
             if (r < 0) {
                 return before;
             } else if (r > 0) {
                 return after;
             }
-            r = compareVersions(getVersion(), other.getVersion());
+            r = compareVersions(getVersion(), otherObject.getVersion());
             if (r < 0) {
                 return before;
             } else if (r > 0) {
                 return after;
             }
-            r = getUpdate().compareTo(other.getUpdate());
+            r = getUpdate().compareTo(otherObject.getUpdate());
             if (r < 0) {
                 return before;
             } else if (r > 0) {
                 return after;
             }
-            r = getEdition().compareTo(other.getEdition());
+            r = getEdition().compareTo(otherObject.getEdition());
             if (r < 0) {
                 return before;
             } else if (r > 0) {
                 return after;
             }
-            r = getLanguage().compareTo(other.getLanguage());
+            r = getLanguage().compareTo(otherObject.getLanguage());
             if (r < 0) {
                 return before;
             } else if (r > 0) {
                 return after;
             }
-            r = getSwEdition().compareTo(other.getSwEdition());
+            r = getSwEdition().compareTo(otherObject.getSwEdition());
             if (r < 0) {
                 return before;
             } else if (r > 0) {
                 return after;
             }
-            r = getTargetSw().compareTo(other.getTargetSw());
+            r = getTargetSw().compareTo(otherObject.getTargetSw());
             if (r < 0) {
                 return before;
             } else if (r > 0) {
                 return after;
             }
-            r = getTargetHw().compareTo(other.getTargetHw());
+            r = getTargetHw().compareTo(otherObject.getTargetHw());
             if (r < 0) {
                 return before;
             } else if (r > 0) {
                 return after;
             }
-            r = getOther().compareTo(other.getOther());
+            r = getOther().compareTo(otherObject.getOther());
             if (r < 0) {
                 return before;
             } else if (r > 0) {

--- a/src/main/java/us/springett/parsers/cpe/CpeParser.java
+++ b/src/main/java/us/springett/parsers/cpe/CpeParser.java
@@ -74,7 +74,7 @@ public final class CpeParser {
         } else if (cpeString.regionMatches(0, "cpe:/", 0, 5)) {
             return parse22(cpeString, lenient);
         } else if (cpeString.regionMatches(0, "cpe:2.3:", 0, 8)) {
-            return parse23(cpeString);
+            return parse23(cpeString, lenient);
         }
         throw new CpeParsingException("The CPE string specified does not conform to the CPE 2.2 or 2.3 specification");
     }
@@ -188,6 +188,19 @@ public final class CpeParser {
      * @throws CpeParsingException thrown if the cpeString is invalid
      */
     protected static Cpe parse23(String cpeString) throws CpeParsingException {
+        return parse23(cpeString, false);
+    }
+
+    /**
+     * Parses a CPE 2.3 Formatted String.
+     *
+     * @param cpeString the CPE string to parse
+     * @param lenient when <code>true</code> the parser will put in lenient mode
+     * attempting to parse invalid CPE values.
+     * @return the CPE object represented by the cpeString
+     * @throws CpeParsingException thrown if the cpeString is invalid
+     */
+    protected static Cpe parse23(String cpeString, boolean lenient) throws CpeParsingException {
         if (cpeString == null || cpeString.isEmpty()) {
             throw new CpeParsingException("CPE String is null ir enpty - unable to parse");
         }
@@ -195,16 +208,16 @@ public final class CpeParser {
         Cpe23PartIterator cpe = new Cpe23PartIterator(cpeString);
         try {
             cb.part(cpe.next());
-            cb.wfVendor(Convert.fsToWellFormed(cpe.next()));
-            cb.wfProduct(Convert.fsToWellFormed(cpe.next()));
-            cb.wfVersion(Convert.fsToWellFormed(cpe.next()));
-            cb.wfUpdate(Convert.fsToWellFormed(cpe.next()));
-            cb.wfEdition(Convert.fsToWellFormed(cpe.next()));
-            cb.wfLanguage(Convert.fsToWellFormed(cpe.next()));
-            cb.wfSwEdition(Convert.fsToWellFormed(cpe.next()));
-            cb.wfTargetSw(Convert.fsToWellFormed(cpe.next()));
-            cb.wfTargetHw(Convert.fsToWellFormed(cpe.next()));
-            cb.wfOther(Convert.fsToWellFormed(cpe.next()));
+            cb.wfVendor(Convert.fsToWellFormed(cpe.next(), lenient));
+            cb.wfProduct(Convert.fsToWellFormed(cpe.next(), lenient));
+            cb.wfVersion(Convert.fsToWellFormed(cpe.next(), lenient));
+            cb.wfUpdate(Convert.fsToWellFormed(cpe.next(), lenient));
+            cb.wfEdition(Convert.fsToWellFormed(cpe.next(), lenient));
+            cb.wfLanguage(Convert.fsToWellFormed(cpe.next(), lenient));
+            cb.wfSwEdition(Convert.fsToWellFormed(cpe.next(), lenient));
+            cb.wfTargetSw(Convert.fsToWellFormed(cpe.next(), lenient));
+            cb.wfTargetHw(Convert.fsToWellFormed(cpe.next(), lenient));
+            cb.wfOther(Convert.fsToWellFormed(cpe.next(), lenient));
         } catch (NoSuchElementException ex) {
             throw new CpeParsingException("Invalid CPE (too few components): " + cpeString);
         }

--- a/src/main/java/us/springett/parsers/cpe/exceptions/CpeEncodingException.java
+++ b/src/main/java/us/springett/parsers/cpe/exceptions/CpeEncodingException.java
@@ -23,6 +23,11 @@ package us.springett.parsers.cpe.exceptions;
 public class CpeEncodingException extends Exception {
 
     /**
+     * Generated serial version UID.
+     */
+    private static final long serialVersionUID = 5364624206915863030L;
+
+    /**
      * Constructs a new exception with the specified detail message.
      *
      * @param message the detailed message

--- a/src/main/java/us/springett/parsers/cpe/exceptions/CpeParsingException.java
+++ b/src/main/java/us/springett/parsers/cpe/exceptions/CpeParsingException.java
@@ -25,6 +25,11 @@ package us.springett.parsers.cpe.exceptions;
 public class CpeParsingException extends Exception {
 
     /**
+     * Generated serial version UID.
+     */
+    private static final long serialVersionUID = -4624394628314058224L;
+
+    /**
      * Constructs a new exception with the specified detail message.
      *
      * @param message the detailed message

--- a/src/main/java/us/springett/parsers/cpe/exceptions/CpeValidationException.java
+++ b/src/main/java/us/springett/parsers/cpe/exceptions/CpeValidationException.java
@@ -25,6 +25,11 @@ package us.springett.parsers.cpe.exceptions;
 public class CpeValidationException extends Exception {
 
     /**
+     * Generated serial version UID.
+     */
+    private static final long serialVersionUID = -7648560659284986374L;
+
+    /**
      * Constructs a new exception with the specified detail message.
      *
      * @param message the detailed message

--- a/src/main/java/us/springett/parsers/cpe/util/Convert.java
+++ b/src/main/java/us/springett/parsers/cpe/util/Convert.java
@@ -174,6 +174,21 @@ public final class Convert {
      * formed
      */
     public static String cpeUriToWellFormed(String value) throws CpeEncodingException {
+        return cpeUriToWellFormed(value, false);
+    }
+
+    /**
+     * CPE URI decodes the value into a well formed string. If the value is NULL
+     * or an empty string then a the LogicalValue.ANY ('*') is returned.
+     *
+     * @param value the CPE URI encoded string to convert
+     * @param lenient whether or not to enable lenient parsing of the CPE URI
+     * value
+     * @return the well formed string representation of the given value
+     * @throws CpeEncodingException thrown if the string provided is not well
+     * formed
+     */
+    public static String cpeUriToWellFormed(String value, boolean lenient) throws CpeEncodingException {
         if (value == null || value.isEmpty() || LogicalValue.ANY.getAbbreviation().equals(value)) {
             return LogicalValue.ANY.getAbbreviation();
         } else if (LogicalValue.NA.getAbbreviation().equals(value)) {
@@ -206,7 +221,11 @@ public final class Convert {
                             break;
                     }
                 } else {
-                    throw new CpeEncodingException("Invalid CPE URI component - unexpected characters");
+                    if (lenient) {
+                        sb.append('\\').append(c);
+                    } else {
+                        throw new CpeEncodingException("Invalid CPE URI component - unexpected characters");
+                    }
                 }
             }
             return sb.toString();

--- a/src/main/java/us/springett/parsers/cpe/util/Convert.java
+++ b/src/main/java/us/springett/parsers/cpe/util/Convert.java
@@ -66,7 +66,7 @@ public final class Convert {
             return value;
         }
         //return value.replaceAll("([^0-9A-Za-z])", "\\\\$1");
-        StringBuffer buffer = new StringBuffer(value);
+        StringBuilder buffer = new StringBuilder(value);
         for (int x = 0; x < buffer.length(); x++) {
             char c = buffer.charAt(x);
             if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'))) {
@@ -89,7 +89,7 @@ public final class Convert {
             return LogicalValue.ANY.getAbbreviation();
         }
         //return value.replaceAll("\\\\([^0-9A-Za-z])", "$1");
-        StringBuffer buffer = new StringBuffer(value);
+        StringBuilder buffer = new StringBuilder(value);
         char p = ' ';
         for (int x = 0; x < buffer.length() - 1; x++) {
             char c = buffer.charAt(x);
@@ -271,7 +271,7 @@ public final class Convert {
         }
         //unquote '.', '_', and '-'
         //return value.replaceAll("\\\\([._-])", "$1");
-        StringBuffer buffer = new StringBuffer(value);
+        StringBuilder buffer = new StringBuilder(value);
         char p = ' ';
         for (int x = 0; x < buffer.length() - 1; x++) {
             char c = buffer.charAt(x);
@@ -342,7 +342,7 @@ public final class Convert {
         }
 
         boolean quoted = false;
-        StringBuffer buffer = new StringBuffer(value);
+        StringBuilder buffer = new StringBuilder(value);
         for (int x = 0; x < buffer.length(); x++) {
             char c = buffer.charAt(x);
             if (c == '.' || c == '_' || c == '-') {

--- a/src/main/java/us/springett/parsers/cpe/util/Convert.java
+++ b/src/main/java/us/springett/parsers/cpe/util/Convert.java
@@ -20,6 +20,8 @@ package us.springett.parsers.cpe.util;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
 import java.io.UnsupportedEncodingException;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import us.springett.parsers.cpe.values.LogicalValue;
 import us.springett.parsers.cpe.values.Part;
 
@@ -34,6 +36,10 @@ public final class Convert {
      * Hexadecimal character sequence used for encoding.
      */
     private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
+    /**
+     * A reference to the logger.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(Convert.class);
 
     /**
      * Private constructor for utility class.
@@ -222,6 +228,8 @@ public final class Convert {
                     }
                 } else {
                     if (lenient) {
+                        //TODO check to ensure that the value is in the ascii range per spec?
+                        LOG.debug("Invalid CPE URI part, '%s'; escaping '%s' as a well formatted string", value, c);
                         sb.append('\\').append(c);
                     } else {
                         throw new CpeEncodingException("Invalid CPE URI component - unexpected characters");

--- a/src/main/java/us/springett/parsers/cpe/util/Validate.java
+++ b/src/main/java/us/springett/parsers/cpe/util/Validate.java
@@ -65,7 +65,7 @@ public final class Validate {
             }
             for (int x = 0; x < value.length(); x++) {
                 char c = value.charAt(x);
-                if (c == '?' && x > 0
+                if (c == '?' && x > 0 && x < value.length() - 1
                         && !((value.charAt(x - 1) == '?' || value.charAt(x - 1) == '*' || value.charAt(x - 1) == '\\')
                         || (x < value.length() - 1 && (value.charAt(x + 1) == '?' || value.charAt(x + 1) == '*')))) {
                     return Status.UNQUOTED_QUESTION_MARK;

--- a/src/test/java/us/springett/parsers/cpe/CpeIT.java
+++ b/src/test/java/us/springett/parsers/cpe/CpeIT.java
@@ -17,18 +17,13 @@
  */
 package us.springett.parsers.cpe;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import us.springett.parsers.cpe.values.Part;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mitre.cpe.common.WellFormedName;
 import org.mitre.cpe.matching.CPENameMatcher;
-import us.springett.parsers.cpe.exceptions.CpeValidationException;
 import us.springett.parsers.cpe.values.LogicalValue;
 
 /**

--- a/src/test/java/us/springett/parsers/cpe/CpeParserTest.java
+++ b/src/test/java/us/springett/parsers/cpe/CpeParserTest.java
@@ -91,6 +91,13 @@ public class CpeParserTest {
         Assert.assertEquals("1.5.1", cpe.getVersion());
         Assert.assertEquals("android", cpe.getTargetSw());
         
+        cpe = CpeParser.parse("cpe:2.3:a:gratta_\\&_vinci?_project:gratta_\\&_vinci?:0.21.13167.93474:*:*:*:*:android:*:*", true);
+        Assert.assertEquals(Part.APPLICATION, cpe.getPart());
+        Assert.assertEquals("gratta_&_vinci?_project", cpe.getVendor());
+        Assert.assertEquals("gratta_&_vinci?", cpe.getProduct());
+        Assert.assertEquals("0.21.13167.93474", cpe.getVersion());
+        Assert.assertEquals("android", cpe.getTargetSw());
+        
         cpe = CpeParser.parse("cpe:2.3:a:*?t?t?*:t#*:*#:*:*:*:*:*:*:*", true);
         Assert.assertEquals(Part.APPLICATION, cpe.getPart());
         Assert.assertEquals("*?t?t?*", cpe.getVendor());

--- a/src/test/java/us/springett/parsers/cpe/CpeParserTest.java
+++ b/src/test/java/us/springett/parsers/cpe/CpeParserTest.java
@@ -81,6 +81,24 @@ public class CpeParserTest {
         Assert.assertEquals("*", cpe.getUpdate());
         Assert.assertEquals("*", cpe.getEdition());
         Assert.assertEquals("*", cpe.getLanguage());
+        
+        
+        
+        cpe = CpeParser.parse("cpe:2.3:a:disney:where\\'s_my_perry?_free:1.5.1:*:*:*:*:android:*:*", true);
+        Assert.assertEquals(Part.APPLICATION, cpe.getPart());
+        Assert.assertEquals("disney", cpe.getVendor());
+        Assert.assertEquals("where's_my_perry?_free", cpe.getProduct());
+        Assert.assertEquals("1.5.1", cpe.getVersion());
+        Assert.assertEquals("android", cpe.getTargetSw());
+        
+        cpe = CpeParser.parse("cpe:2.3:a:*?t?t?*:t#*:*#:*:*:*:*:*:*:*", true);
+        Assert.assertEquals(Part.APPLICATION, cpe.getPart());
+        Assert.assertEquals("*?t?t?*", cpe.getVendor());
+        Assert.assertEquals("*?t\\?t?*", cpe.getWellFormedVendor());
+        Assert.assertEquals("t#*", cpe.getProduct());
+        Assert.assertEquals("t\\#*", cpe.getWellFormedProduct());
+        Assert.assertEquals("*#", cpe.getVersion());
+        Assert.assertEquals("*\\#", cpe.getWellFormedVersion());
     }
 
     @Test

--- a/src/test/java/us/springett/parsers/cpe/CpeParserTest.java
+++ b/src/test/java/us/springett/parsers/cpe/CpeParserTest.java
@@ -72,6 +72,29 @@ public class CpeParserTest {
         Assert.assertEquals("chrome", cpe.getTargetSw());
         Assert.assertEquals("*", cpe.getTargetHw());
         Assert.assertEquals("*", cpe.getOther());
+
+        cpe = CpeParser.parse("cpe:/a:oracle:connector/j:5.1.27", true);
+        Assert.assertEquals(Part.APPLICATION, cpe.getPart());
+        Assert.assertEquals("oracle", cpe.getVendor());
+        Assert.assertEquals("connector/j", cpe.getProduct());
+        Assert.assertEquals("5.1.27", cpe.getVersion());
+        Assert.assertEquals("*", cpe.getUpdate());
+        Assert.assertEquals("*", cpe.getEdition());
+        Assert.assertEquals("*", cpe.getLanguage());
+    }
+
+    @Test
+    public void testParseException() throws CpeParsingException {
+        exception.expect(CpeParsingException.class);
+        
+        Cpe cpe = CpeParser.parse("cpe:/a:oracle:connector/j:5.1.27", false);
+        Assert.assertEquals(Part.APPLICATION, cpe.getPart());
+        Assert.assertEquals("oracle", cpe.getVendor());
+        Assert.assertEquals("connector/j", cpe.getProduct());
+        Assert.assertEquals("5.1.27", cpe.getVersion());
+        Assert.assertEquals("*", cpe.getUpdate());
+        Assert.assertEquals("*", cpe.getEdition());
+        Assert.assertEquals("*", cpe.getLanguage());
     }
 
     /**
@@ -108,8 +131,7 @@ public class CpeParserTest {
         Assert.assertEquals("*", cpe.getTargetSw());
         Assert.assertEquals("*", cpe.getTargetHw());
         Assert.assertEquals("*", cpe.getOther());
-        
-        
+
         cpe = CpeParser.parse23("cpe:2.3:a:jenkins:pipeline\\:build_step:*:*:*:*:*:jenkins:*:*");
         Assert.assertEquals(Part.APPLICATION, cpe.getPart());
         Assert.assertEquals("jenkins", cpe.getVendor());
@@ -199,6 +221,77 @@ public class CpeParserTest {
         Assert.assertEquals("*", cpe.getOther());
     }
 
+    
+    @Test
+    public void testParse22Lenient() throws Exception {
+        exception = ExpectedException.none();
+
+        Cpe cpe = CpeParser.parse22("cpe:/a:microsoft:internet_explorer%01%01%01%01:%01:beta::c%2b%2b",true);
+        Assert.assertEquals(Part.APPLICATION, cpe.getPart());
+        Assert.assertEquals("microsoft", cpe.getVendor());
+        Assert.assertEquals("internet_explorer????", cpe.getProduct());
+        Assert.assertEquals("?", cpe.getVersion());
+        Assert.assertEquals("beta", cpe.getUpdate());
+        Assert.assertEquals("*", cpe.getEdition());
+        Assert.assertEquals("c++", cpe.getLanguage());
+        Assert.assertEquals("*", cpe.getSwEdition());
+        Assert.assertEquals("*", cpe.getTargetSw());
+        Assert.assertEquals("*", cpe.getTargetHw());
+        Assert.assertEquals("*", cpe.getOther());
+
+        cpe = CpeParser.parse22("cpe:/a:microsoft:internet_explorer%01%01%01%01:%01",true);
+        Assert.assertEquals(Part.APPLICATION, cpe.getPart());
+        Assert.assertEquals("microsoft", cpe.getVendor());
+        Assert.assertEquals("internet_explorer????", cpe.getProduct());
+        Assert.assertEquals("?", cpe.getVersion());
+        Assert.assertEquals("*", cpe.getUpdate());
+        Assert.assertEquals("*", cpe.getEdition());
+        Assert.assertEquals("*", cpe.getLanguage());
+        Assert.assertEquals("*", cpe.getSwEdition());
+        Assert.assertEquals("*", cpe.getTargetSw());
+        Assert.assertEquals("*", cpe.getTargetHw());
+        Assert.assertEquals("*", cpe.getOther());
+
+        cpe = CpeParser.parse22("cpe:/a:microsoft:internet_explorer%01%01%01%01",true);
+        Assert.assertEquals(Part.APPLICATION, cpe.getPart());
+        Assert.assertEquals("microsoft", cpe.getVendor());
+        Assert.assertEquals("internet_explorer????", cpe.getProduct());
+        Assert.assertEquals("*", cpe.getVersion());
+        Assert.assertEquals("*", cpe.getUpdate());
+        Assert.assertEquals("*", cpe.getEdition());
+        Assert.assertEquals("*", cpe.getLanguage());
+        Assert.assertEquals("*", cpe.getSwEdition());
+        Assert.assertEquals("*", cpe.getTargetSw());
+        Assert.assertEquals("*", cpe.getTargetHw());
+        Assert.assertEquals("*", cpe.getOther());
+
+        cpe = CpeParser.parse22("cpe:/a:microsoft",true);
+        Assert.assertEquals(Part.APPLICATION, cpe.getPart());
+        Assert.assertEquals("microsoft", cpe.getVendor());
+        Assert.assertEquals("*", cpe.getProduct());
+        Assert.assertEquals("*", cpe.getVersion());
+        Assert.assertEquals("*", cpe.getUpdate());
+        Assert.assertEquals("*", cpe.getEdition());
+        Assert.assertEquals("*", cpe.getLanguage());
+        Assert.assertEquals("*", cpe.getSwEdition());
+        Assert.assertEquals("*", cpe.getTargetSw());
+        Assert.assertEquals("*", cpe.getTargetHw());
+        Assert.assertEquals("*", cpe.getOther());
+
+        cpe = CpeParser.parse22("cpe:/a:",true);
+        Assert.assertEquals(Part.APPLICATION, cpe.getPart());
+        Assert.assertEquals("*", cpe.getVendor());
+        Assert.assertEquals("*", cpe.getProduct());
+        Assert.assertEquals("*", cpe.getVersion());
+        Assert.assertEquals("*", cpe.getUpdate());
+        Assert.assertEquals("*", cpe.getEdition());
+        Assert.assertEquals("*", cpe.getLanguage());
+        Assert.assertEquals("*", cpe.getSwEdition());
+        Assert.assertEquals("*", cpe.getTargetSw());
+        Assert.assertEquals("*", cpe.getTargetHw());
+        Assert.assertEquals("*", cpe.getOther());
+    }
+    
     /**
      * Test of unpackEdition method, of class CpeParser.
      *
@@ -210,7 +303,7 @@ public class CpeParserTest {
 
         CpeBuilder cb = new CpeBuilder();
         String edition = null;
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         Cpe cpe = cb.build();
         assertEquals("*", cpe.getEdition());
         assertEquals("*", cpe.getSwEdition());
@@ -219,7 +312,7 @@ public class CpeParserTest {
         assertEquals("*", cpe.getOther());
 
         edition = "";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("*", cpe.getEdition());
         assertEquals("*", cpe.getSwEdition());
@@ -228,7 +321,7 @@ public class CpeParserTest {
         assertEquals("*", cpe.getOther());
 
         edition = "one";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("one", cpe.getEdition());
         assertEquals("*", cpe.getSwEdition());
@@ -237,7 +330,7 @@ public class CpeParserTest {
         assertEquals("*", cpe.getOther());
 
         edition = "~e~sw~ts~th~o";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("e", cpe.getEdition());
         assertEquals("sw", cpe.getSwEdition());
@@ -246,7 +339,7 @@ public class CpeParserTest {
         assertEquals("o", cpe.getOther());
 
         edition = "~~sw~ts~th~o";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("*", cpe.getEdition());
         assertEquals("sw", cpe.getSwEdition());
@@ -255,7 +348,7 @@ public class CpeParserTest {
         assertEquals("o", cpe.getOther());
 
         edition = "~e~sw~ts~th~";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("e", cpe.getEdition());
         assertEquals("sw", cpe.getSwEdition());
@@ -264,7 +357,7 @@ public class CpeParserTest {
         assertEquals("*", cpe.getOther());
 
         edition = "~~sw~ts~th~";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("*", cpe.getEdition());
         assertEquals("sw", cpe.getSwEdition());
@@ -273,7 +366,7 @@ public class CpeParserTest {
         assertEquals("*", cpe.getOther());
 
         edition = "~~~ts~th~";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("*", cpe.getEdition());
         assertEquals("*", cpe.getSwEdition());
@@ -282,7 +375,7 @@ public class CpeParserTest {
         assertEquals("*", cpe.getOther());
 
         edition = "~~sw~~~";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("*", cpe.getEdition());
         assertEquals("sw", cpe.getSwEdition());
@@ -291,7 +384,7 @@ public class CpeParserTest {
         assertEquals("*", cpe.getOther());
 
         edition = "~~~~th~";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("*", cpe.getEdition());
         assertEquals("*", cpe.getSwEdition());
@@ -300,7 +393,7 @@ public class CpeParserTest {
         assertEquals("*", cpe.getOther());
 
         edition = "~~~~~";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("*", cpe.getEdition());
         assertEquals("*", cpe.getSwEdition());
@@ -309,13 +402,92 @@ public class CpeParserTest {
         assertEquals("*", cpe.getOther());
 
         edition = "~~~chrome~~";
-        CpeParser.unpackEdition(edition, cb);
+        CpeParser.unpackEdition(edition, cb, false);
         cpe = cb.build();
         assertEquals("*", cpe.getEdition());
         assertEquals("*", cpe.getSwEdition());
         assertEquals("chrome", cpe.getTargetSw());
         assertEquals("*", cpe.getTargetHw());
         assertEquals("*", cpe.getOther());
+
+        edition = "~test/test~test?test~test:test~test&test~test*test";
+        CpeParser.unpackEdition(edition, cb, true);
+        cpe = cb.build();
+        assertEquals("test\\/test", cpe.getWellFormedEdition());
+        assertEquals("test\\?test", cpe.getWellFormedSwEdition());
+        assertEquals("test\\:test", cpe.getWellFormedTargetSw());
+        assertEquals("test\\&test", cpe.getWellFormedTargetHw());
+        assertEquals("test\\*test", cpe.getWellFormedOther());
+    }
+
+    @Test
+    public void testUnpackEditionException1() throws Exception {
+        exception.expect(CpeParsingException.class);
+        CpeBuilder cb = new CpeBuilder();
+        String edition = "~test/test~test?test~test:test~test&test~test*test";
+        CpeParser.unpackEdition(edition, cb, false);
+        Cpe cpe = cb.build();
+        assertEquals("test\\/test", cpe.getWellFormedEdition());
+        assertEquals("test\\?test", cpe.getWellFormedSwEdition());
+        assertEquals("test\\:test", cpe.getWellFormedTargetSw());
+        assertEquals("test\\&test", cpe.getWellFormedTargetHw());
+        assertEquals("test\\*test", cpe.getWellFormedOther());
+    }
+
+    @Test
+    public void testUnpackEditionException2() throws Exception {
+        exception.expect(CpeParsingException.class);
+        CpeBuilder cb = new CpeBuilder();
+        String edition = "~test~test?test~test:test~test&test~test*test";
+        CpeParser.unpackEdition(edition, cb, false);
+        Cpe cpe = cb.build();
+        assertEquals("test", cpe.getWellFormedEdition());
+        assertEquals("test\\?test", cpe.getWellFormedSwEdition());
+        assertEquals("test\\:test", cpe.getWellFormedTargetSw());
+        assertEquals("test\\&test", cpe.getWellFormedTargetHw());
+        assertEquals("test\\*test", cpe.getWellFormedOther());
+    }
+
+    @Test
+    public void testUnpackEditionException3() throws Exception {
+        exception.expect(CpeParsingException.class);
+        CpeBuilder cb = new CpeBuilder();
+        String edition = "~test~test~test:test~test&test~test*test";
+        CpeParser.unpackEdition(edition, cb, false);
+        Cpe cpe = cb.build();
+        assertEquals("test", cpe.getWellFormedEdition());
+        assertEquals("test", cpe.getWellFormedSwEdition());
+        assertEquals("test\\:test", cpe.getWellFormedTargetSw());
+        assertEquals("test\\&test", cpe.getWellFormedTargetHw());
+        assertEquals("test\\*test", cpe.getWellFormedOther());
+    }
+
+    @Test
+    public void testUnpackEditionException4() throws Exception {
+        exception.expect(CpeParsingException.class);
+        CpeBuilder cb = new CpeBuilder();
+        String edition = "~test~test~test~test&test~test*test";
+        CpeParser.unpackEdition(edition, cb, false);
+        Cpe cpe = cb.build();
+        assertEquals("test", cpe.getWellFormedEdition());
+        assertEquals("test", cpe.getWellFormedSwEdition());
+        assertEquals("test", cpe.getWellFormedTargetSw());
+        assertEquals("test\\&test", cpe.getWellFormedTargetHw());
+        assertEquals("test\\*test", cpe.getWellFormedOther());
+    }
+
+    @Test
+    public void testUnpackEditionException5() throws Exception {
+        exception.expect(CpeParsingException.class);
+        CpeBuilder cb = new CpeBuilder();
+        String edition = "~test~test~test~test~test*test";
+        CpeParser.unpackEdition(edition, cb, false);
+        Cpe cpe = cb.build();
+        assertEquals("test", cpe.getWellFormedEdition());
+        assertEquals("test", cpe.getWellFormedSwEdition());
+        assertEquals("test", cpe.getWellFormedTargetSw());
+        assertEquals("test", cpe.getWellFormedTargetHw());
+        assertEquals("test\\*test", cpe.getWellFormedOther());
     }
 
     /**

--- a/src/test/java/us/springett/parsers/cpe/CpeTest.java
+++ b/src/test/java/us/springett/parsers/cpe/CpeTest.java
@@ -740,8 +740,9 @@ public class CpeTest {
         result = instance.equals("test");
         assertEquals(expResult, result);
 
+        obj = null;
         expResult = false;
-        result = instance.equals(null);
+        result = instance.equals(obj);
         assertEquals(expResult, result);
     }
 

--- a/src/test/java/us/springett/parsers/cpe/util/ConvertIT.java
+++ b/src/test/java/us/springett/parsers/cpe/util/ConvertIT.java
@@ -19,14 +19,9 @@ package us.springett.parsers.cpe.util;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 import us.springett.parsers.cpe.values.LogicalValue;
-import us.springett.parsers.cpe.values.Part;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
-import us.springett.parsers.cpe.exceptions.CpeEncodingException;
 
 /**
  *
@@ -47,7 +42,7 @@ public class ConvertIT {
 
     @Test
     public void testPerformance() throws Exception {
-        List<String> values = new ArrayList<String>();
+        List<String> values = new ArrayList<>();
 
         System.out.println("---------------------------------------------------");
         System.out.println("Performance test building data set");

--- a/src/test/java/us/springett/parsers/cpe/util/ConvertIT.java
+++ b/src/test/java/us/springett/parsers/cpe/util/ConvertIT.java
@@ -56,11 +56,13 @@ public class ConvertIT {
             values.add("aaaaaaaaaaaaaaaaaa:5.3." + i);
         }
 
-        for (int i = 0; i < 10; i++) {
-            String res = Convert.toWellFormed(values.get(i));
-            String ref = referenceToWellFormed(values.get(i));
-            assertTrue(res.equals(ref));
-        }
+        values.forEach(
+                (cpe) -> {
+                    String res = Convert.toWellFormed(cpe);
+                    String ref = referenceToWellFormed(cpe);
+                    assertTrue(res.equals(ref));
+                }
+        );
 
         System.out.println(
                 "Performance test starting reference");

--- a/src/test/java/us/springett/parsers/cpe/util/ConvertTest.java
+++ b/src/test/java/us/springett/parsers/cpe/util/ConvertTest.java
@@ -430,4 +430,22 @@ public class ConvertTest {
         assertEquals(expResult.toString(), result.toString());
 
     }
+
+    @Test
+    public void testCpeUriToWellFormedLenient() throws Exception {
+        exception = ExpectedException.none();
+        String value = "te/st";
+        String expResult = "te\\/st";
+        String result = Convert.cpeUriToWellFormed(value, true);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void testCpeUriToWellFormedLenientException() throws Exception {
+        exception.expect(CpeEncodingException.class);
+        String value = "te/st";
+        String expResult = "te\\/st";
+        String result = Convert.cpeUriToWellFormed(value, false);
+        assertEquals(expResult, result);
+    }
 }

--- a/src/test/java/us/springett/parsers/cpe/util/ValidateIT.java
+++ b/src/test/java/us/springett/parsers/cpe/util/ValidateIT.java
@@ -48,7 +48,7 @@ public class ValidateIT {
 
     @Test
     public void testPerformance() throws Exception {
-        List<String> cpes = new ArrayList<String>();
+        List<String> cpes = new ArrayList<>();
 
         System.out.println("---------------------------------------------------");
         System.out.println("Performance test building data set");

--- a/src/test/java/us/springett/parsers/cpe/util/ValidateTest.java
+++ b/src/test/java/us/springett/parsers/cpe/util/ValidateTest.java
@@ -108,6 +108,9 @@ public class ValidateTest {
         value = "foobar?*";
         assertTrue(Validate.component(value).isValid());
 
+        value = "foobar?";
+        assertTrue(Validate.component(value).isValid());
+        
         char[] str = {10, 34};
         value = new String(str);
         assertFalse(Validate.component(value).isValid());


### PR DESCRIPTION
Updated CPE 2.2 URI parsing to allow optional lenient parsing.  The NVD contains a number of CPE values that are not correctly encoded. Example:

```
cpe:/a:oracle:connector/j:5.1.27
```

This PR enables lenient parsing so that the forward slash, which should be URI encoded, will be successfully processed and result in the following Formatted String:

```
cpe:2.3:a:oracle:connector\/j:5.1.27:*:*:*:*:*:*:*
```