### PR TITLE
CPE: Fix false negative on part comparison

### DIFF
--- a/src/main/java/us/springett/parsers/cpe/Cpe.java
+++ b/src/main/java/us/springett/parsers/cpe/Cpe.java
@@ -582,9 +582,16 @@ public class Cpe implements ICpe, Serializable {
      * otherwise <code>false</code>
      */
     protected static boolean compareAttributes(Part left, Part right) {
+        //1 6 9 - equals
         if (left == right) {
             return true;
-        } else if (left == Part.ANY) {
+        }
+        //2 3 - superset (4 does not apply due to enum)
+        else if (left == Part.ANY) {
+            return true;
+        }
+        //5 13 - subset (15 does not apply due to enum)
+        else if (right == Part.ANY) {
             return true;
         }
         return false;

--- a/src/test/java/us/springett/parsers/cpe/CpeTest.java
+++ b/src/test/java/us/springett/parsers/cpe/CpeTest.java
@@ -769,7 +769,7 @@ public class CpeTest {
         assertFalse(Cpe.compareAttributes(Part.APPLICATION, Part.HARDWARE_DEVICE));
         assertFalse(Cpe.compareAttributes(Part.APPLICATION, Part.OPERATING_SYSTEM));
         assertFalse(Cpe.compareAttributes(Part.APPLICATION, Part.NA));
-        assertFalse(Cpe.compareAttributes(Part.APPLICATION, Part.ANY));
+        assertTrue(Cpe.compareAttributes(Part.APPLICATION, Part.ANY));
 
         assertTrue(Cpe.compareAttributes(Part.ANY, Part.ANY));
         assertTrue(Cpe.compareAttributes(Part.ANY, Part.APPLICATION));
@@ -778,7 +778,7 @@ public class CpeTest {
         assertTrue(Cpe.compareAttributes(Part.ANY, Part.NA));
 
         assertTrue(Cpe.compareAttributes(Part.NA, Part.NA));
-        assertFalse(Cpe.compareAttributes(Part.NA, Part.ANY));
+        assertTrue(Cpe.compareAttributes(Part.NA, Part.ANY));
         assertFalse(Cpe.compareAttributes(Part.NA, Part.APPLICATION));
         assertFalse(Cpe.compareAttributes(Part.NA, Part.HARDWARE_DEVICE));
         assertFalse(Cpe.compareAttributes(Part.NA, Part.OPERATING_SYSTEM));


### PR DESCRIPTION
Previously, comparing CPEs will cause false negatives, if the component (right) "part" contains an "ANY" value, while the CVE (left) contains a string value or logical value "NA".

Instead, this should return a match, as defined by cases 5, 13, 15 within table 6-2 in the [NIST name matching specification](https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7696.pdf).