### PR TITLE
Return the relation type when comparing CPE attributes

### DIFF
--- a/src/main/java/us/springett/parsers/cpe/util/Relation.java
+++ b/src/main/java/us/springett/parsers/cpe/util/Relation.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of CPE Parser.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package us.springett.parsers.cpe.util;
+
+/**
+ * Possible set relations between source WFN and target WFN.
+ *
+ * @see <a href="https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7696.pdf">NIST CPE Name Matching Specification, Table 6-1</a>
+ */
+public enum Relation {
+
+    /**
+     * The source and target are mutually exclusive or DISJOINT.
+     */
+    DISJOINT,
+
+    /**
+     * The source and target are EQUAL.
+     */
+    EQUAL,
+
+    /**
+     * The source is a SUBSET of the target.
+     */
+    SUBSET,
+
+    /**
+     * The source is a SUPERSET of the target.
+     */
+    SUPERSET
+
+}

--- a/src/test/java/us/springett/parsers/cpe/CpeTest.java
+++ b/src/test/java/us/springett/parsers/cpe/CpeTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.After;
 import org.junit.AfterClass;
+import us.springett.parsers.cpe.util.Relation;
 import us.springett.parsers.cpe.values.Part;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -784,6 +785,27 @@ public class CpeTest {
         assertFalse(Cpe.compareAttributes(Part.NA, Part.OPERATING_SYSTEM));
     }
 
+    @Test
+    public void testCompareAttribute_Part_Part_Relation() {
+        assertEquals(Relation.EQUAL, Cpe.compareAttribute(Part.APPLICATION, Part.APPLICATION));
+        assertEquals(Relation.DISJOINT, Cpe.compareAttribute(Part.APPLICATION, Part.HARDWARE_DEVICE));
+        assertEquals(Relation.DISJOINT, Cpe.compareAttribute(Part.APPLICATION, Part.OPERATING_SYSTEM));
+        assertEquals(Relation.DISJOINT, Cpe.compareAttribute(Part.APPLICATION, Part.NA));
+        assertEquals(Relation.SUBSET, Cpe.compareAttribute(Part.APPLICATION, Part.ANY));
+
+        assertEquals(Relation.EQUAL, Cpe.compareAttribute(Part.ANY, Part.ANY));
+        assertEquals(Relation.SUPERSET, Cpe.compareAttribute(Part.ANY, Part.APPLICATION));
+        assertEquals(Relation.SUPERSET, Cpe.compareAttribute(Part.ANY, Part.OPERATING_SYSTEM));
+        assertEquals(Relation.SUPERSET, Cpe.compareAttribute(Part.ANY, Part.HARDWARE_DEVICE));
+        assertEquals(Relation.SUPERSET, Cpe.compareAttribute(Part.ANY, Part.NA));
+
+        assertEquals(Relation.EQUAL, Cpe.compareAttribute(Part.NA, Part.NA));
+        assertEquals(Relation.SUBSET, Cpe.compareAttribute(Part.NA, Part.ANY));
+        assertEquals(Relation.DISJOINT, Cpe.compareAttribute(Part.NA, Part.APPLICATION));
+        assertEquals(Relation.DISJOINT, Cpe.compareAttribute(Part.NA, Part.HARDWARE_DEVICE));
+        assertEquals(Relation.DISJOINT, Cpe.compareAttribute(Part.NA, Part.OPERATING_SYSTEM));
+    }
+
     /**
      * Test of compareAttributes method, of class Cpe.
      */
@@ -796,6 +818,17 @@ public class CpeTest {
         assertFalse(Cpe.compareAttributes("abc", "abcdef"));
         assertTrue(Cpe.compareAttributes("abc*", "abcdef"));
         assertFalse(Cpe.compareAttributes("abc??", "abcdef"));
+    }
+
+    @Test
+    public void testCompareAttribute_String_String_Relation() {
+        assertEquals(Relation.EQUAL, Cpe.compareAttribute("a", "a"));
+        assertEquals(Relation.EQUAL, Cpe.compareAttribute("a", "A"));
+        assertEquals(Relation.SUPERSET, Cpe.compareAttribute("abc?", "abcd"));
+        assertEquals(Relation.EQUAL, Cpe.compareAttribute("abc\\:def", "abc\\:def"));
+        assertEquals(Relation.DISJOINT, Cpe.compareAttribute("abc", "abcdef"));
+        assertEquals(Relation.SUPERSET, Cpe.compareAttribute("abc*", "abcdef"));
+        assertEquals(Relation.DISJOINT, Cpe.compareAttribute("abc??", "abcdef"));
     }
 
     /**


### PR DESCRIPTION
Table 6-4 of the NIST spec defines conditions under which a comparison result of all CPE fields should be considered a match. Evaluating this requires knowledge of the relation type of each comparison.

<img width="785" alt="image" src="https://github.com/stevespringett/CPE-Parser/assets/5693141/6466f009-0de6-44f4-b105-00a331b5de85">


Credit to @Jasper-Ben for catching this: https://github.com/DependencyTrack/dependency-track/issues/3178#issuecomment-1812809295