### PR TITLE
fix: allow parsing of empty CPE 2.2 part

### DIFF
--- a/src/main/java/us/springett/parsers/cpe/CpeParser.java
+++ b/src/main/java/us/springett/parsers/cpe/CpeParser.java
@@ -108,11 +108,13 @@ public final class CpeParser {
         if (parts.length <= 1 || parts.length > 8) {
             throw new CpeParsingException("CPE String is invalid - too many components specified: " + cpeString);
         }
-        if (parts[1].length() != 2) {
+        if (parts[1].length() == 0 || parts[1].length() > 2) {
             throw new CpeParsingException("CPE String contains a malformed part: " + cpeString);
         }
         try {
-            cb.part(parts[1].substring(1));
+            if (parts[1].length() > 1) {
+                cb.part(parts[1].substring(1));
+            }
             if (parts.length > 2) {
                 cb.wfVendor(Convert.cpeUriToWellFormed(parts[2], lenient));
             }

--- a/src/test/java/us/springett/parsers/cpe/CpeParserTest.java
+++ b/src/test/java/us/springett/parsers/cpe/CpeParserTest.java
@@ -636,4 +636,11 @@ public class CpeParserTest {
         exception.expect(CpeParsingException.class);
         CpeParser.parse22("cpe:/t:vendor:product:1.0");
     }
+
+    @Test
+    public void testEmptyPart() throws Exception {
+        Cpe cpe = CpeParser.parse22("cpe:/:redhat:enterprise_linux:::hypervisor");
+        assertEquals(Part.ANY, cpe.getPart());
+        assertEquals("cpe:/*:redhat:enterprise_linux:::hypervisor", cpe.toCpe22Uri());
+    }
 }


### PR DESCRIPTION
fixes #202

An empty part will be treated as ANY. This is consistent with the NVD reference implementation.